### PR TITLE
load config file in use rather than the template

### DIFF
--- a/bin/minindn
+++ b/bin/minindn
@@ -250,7 +250,7 @@ def execute(options):
 
     # Update nfd.conf file used by Mini-NDN to match the currently installed version of NFD
     nfdConfFile = "%s/nfd.conf" % install_dir
-    os.system("sudo cp /usr/local/etc/ndn/nfd.conf.sample %s" % nfdConfFile)
+    os.system("sudo cp /usr/local/etc/ndn/nfd.conf %s" % nfdConfFile)
     os.system("sudo sed -i \'s|default_level [A-Z]*$|default_level $LOG_LEVEL|g\' %s" % nfdConfFile)
 
     if options.resultDir is not None:


### PR DESCRIPTION
In this way, the script is loading the template file rather then the configuration file actually used by the daemon to run on the host machine.
By default nfd loads the configuration file at "/usr/local/etc/ndn/nfd.conf", so I guess it's pretty safe to hardcode this path instead.
