### PR TITLE
Quiet APT install for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ else
   git clone --depth 1 https://github.com/named-data/mini-ndn.git
   pushd mini-ndn
 fi
-./install.sh -a
+./install.sh -q -a
 
 SCRIPT
 

--- a/install.sh
+++ b/install.sh
@@ -109,6 +109,14 @@ function patchDummy {
     fi
 }
 
+function quiet_install {
+    if [[ $DIST == Ubuntu || $DIST == Debian ]]; then
+	update='sudo DEBIAN_FRONTEND=noninteractive apt-get update'
+	install='sudo DEBIAN_FRONTEND=noninteractive apt-get -y install'
+        remove='sudo DEBIAN_FRONTEND=noninteractive apt-get -y remove'
+    fi
+}
+
 function ndn_install {
     mkdir -p $NDN_SRC
     name=$1
@@ -344,13 +352,14 @@ function usage {
     printf -- ' -m: install mininet and dependencies\n' >&2
     printf -- ' -n: install NDN dependencies of mini-ndn including infoedit\n' >&2
     printf -- ' -p: patch ndn-cxx with dummy key chain\n' >&2
+    printf -- ' -q: quiet install\n' >&2
     exit 2
 }
 
 if [[ $# -eq 0 ]]; then
     usage
 else
-    while getopts 'acdhimnp' OPTION
+    while getopts 'acdhimnpq' OPTION
     do
         case $OPTION in
         a)
@@ -367,6 +376,7 @@ else
         m)    mininet;;
         n)    ndn;;
         p)    patchDummy;;
+        q)    quiet_install;;
         ?)    usage;;
         esac
     done

--- a/install.sh
+++ b/install.sh
@@ -114,6 +114,8 @@ function quiet_install {
 	update='sudo DEBIAN_FRONTEND=noninteractive apt-get update'
 	install='sudo DEBIAN_FRONTEND=noninteractive apt-get -y install'
         remove='sudo DEBIAN_FRONTEND=noninteractive apt-get -y remove'
+        
+	echo "wireshark-common wireshark-common/install-setuid boolean false" | sudo debconf-set-selections
     fi
 }
 


### PR DESCRIPTION
Vagrant VM provisioning doesn't have any mechanism for user interaction. For this reason, it is necessary to tell APT that we are in a non-interactive session and any install question should be answered automatically by its preset.

For this reason, according to issue #42, I propose to add "quiet" option to `install.sh`. This option tells Debian-based systems to run APT in non-interactive mode. In case of important questions during install, we can update the preset list specified in `quiet_install` subroutine.

Flag functionality can always be extended in the future to support unexpected cases where Vagrant provision hangs due to user interaction request by some other program.